### PR TITLE
Top-level label sheet generator

### DIFF
--- a/labelcore/GroupReplacer.py
+++ b/labelcore/GroupReplacer.py
@@ -2,6 +2,8 @@ from typing import List
 from abc import ABCMeta, abstractmethod
 
 import xml.etree.ElementTree as ET
+
+from . import SvgTemplate
 from .common import BadTemplateException, SVG_NAMESPACE
 
 
@@ -12,7 +14,7 @@ class GroupReplacer(metaclass=ABCMeta):
   which is when invoked on the group (minus the text box) to mutate it as needed.
   """
   @abstractmethod
-  def process_group(self, elt: List[ET.Element]) -> List[ET.Element]:
+  def process_group(self, context: SvgTemplate, elt: List[ET.Element]) -> List[ET.Element]:
     """Given the group contents (minus the textbox), returns the new group contents."""
     raise NotImplementedError
 
@@ -20,12 +22,12 @@ class GroupReplacer(metaclass=ABCMeta):
 class RectGroupReplacer(GroupReplacer):
   """A GroupReplacer where the group only contains the textbox and a rect (eg, for area sizing).
   """
-  def process_group(self, elts: List[ET.Element]) -> List[ET.Element]:
+  def process_group(self, context: SvgTemplate, elts: List[ET.Element]) -> List[ET.Element]:
     if len(elts) != 1 or elts[0].tag != f'{SVG_NAMESPACE}rect':
       group_tags = [elt.tag for elt in elts]
       raise BadTemplateException(f"{self.__class__.__name__}(RectGroupReplacer) expects single rect, got {group_tags}")
-    return self.process_rect(elts[0])
+    return self.process_rect(context, elts[0])
 
   @abstractmethod
-  def process_rect(self, rect: ET.Element) -> List[ET.Element]:
+  def process_rect(self, context: SvgTemplate, rect: ET.Element) -> List[ET.Element]:
     raise NotImplementedError

--- a/labelcore/InkscapeSubprocess.py
+++ b/labelcore/InkscapeSubprocess.py
@@ -1,0 +1,23 @@
+import subprocess
+
+
+class InkscapeSubprocess:
+  def __init__(self) -> None:
+    self.process = subprocess.Popen("inkscape --shell", stdin=subprocess.PIPE)
+    # don't block for Inkscape to start up, just start sending commands
+
+  def convert(self, filename_in: str, filename_out: str) -> None:
+    # IMPORTANT - this does not check for conversion completion
+    assert self.process.stdin
+    self.process.stdin.write(str.encode(f'file-open:{filename_in};export-filename:{filename_out};export-do;\r\n'))
+    self.process.stdin.flush()
+
+  def close(self) -> None:
+    assert self.process.stdin
+    self.process.stdin.write(b'quit\r\n')
+    self.process.stdin.flush()
+    try:
+      self.process.communicate(timeout=15)  # in case Inkscape is still working
+    except subprocess.TimeoutExpired:
+      self.process.kill()
+      print('Inkscape failed to close gracefully')

--- a/labelcore/InkscapeSubprocess.py
+++ b/labelcore/InkscapeSubprocess.py
@@ -2,6 +2,13 @@ import subprocess
 
 
 class InkscapeSubprocess:
+  """
+  A class for an Inkscape subprocess to convert SVG to PDF.
+
+  We use Inkscape instead of ReportLab / svglib because svglib doesn't seem to render some features correctly,
+  like flowRegion.
+  Inkscape in shell mode is also pretty responsive.
+  """
   def __init__(self) -> None:
     self.process = subprocess.Popen("inkscape --shell", stdin=subprocess.PIPE)
     # don't block for Inkscape to start up, just start sending commands

--- a/labelcore/SvgTemplate.py
+++ b/labelcore/SvgTemplate.py
@@ -2,6 +2,7 @@ import xml.etree.ElementTree as ET
 from typing import Any, Dict, Callable, Optional, cast, List, Tuple, OrderedDict
 from copy import deepcopy, copy
 
+import os.path
 from labelfrontend import LabelSheet
 from labelfrontend.units import LengthDimension
 from .common import BadTemplateException, SVG_NAMESPACE, NAMESPACES, SVG_GRAPHICS_TAGS
@@ -36,7 +37,9 @@ def visit(elt: ET.Element, fn: Callable[[ET.Element], None]) -> None:
 
 
 class SvgTemplate:
-  def __init__(self, root: ET.ElementTree):
+  def __init__(self, filename: str):
+    self.file_abspath = os.path.abspath(filename)
+    root = ET.parse(filename)
     self.env: Dict[str, Any] = cast(Any, None)
     self.sheet: LabelSheet = cast(Any, None)
     self.size: Tuple[LengthDimension, LengthDimension]
@@ -83,11 +86,11 @@ class SvgTemplate:
         self.template_elts.append(deepcopy(child))
         self.skeleton.remove(child)
 
-  def create_single(self) -> ET.Element:
+  def _create_instance(self) -> ET.Element:
     """Creates the top-level SVG object for a single label."""
     return deepcopy(self.skeleton)
 
-  def create_sheet(self) -> ET.Element:
+  def _create_sheet(self) -> ET.Element:
     """Creates the top-level SVG object for a sheet.
     TODO - separate responsibilities with create_single? perhaps sheets should be a different object entirely?
     """
@@ -126,7 +129,7 @@ class SvgTemplate:
           raise BadTemplateException(f'🐍 textbox expected result of type GroupReplacer, got {type(obj)}, in {code}')
         elt.remove(text_child_elts[0])
 
-        new_elts = obj.process_group(list(elt))
+        new_elts = obj.process_group(self, list(elt))
         for child in list(elt):  # elt.clear also deletes attribs
           elt.remove(child)
         elt.extend(new_elts)
@@ -142,23 +145,23 @@ class SvgTemplate:
       new_root.append(new_elt)
     return new_root
 
-  def apply_table(self, table: List[Dict[str, str]]) -> List[ET.Element]:
-    """Given an entire table, generates sheet(s) of labels."""
-    sheets = []
+  def apply_page(self, table: List[Dict[str, str]]) -> ET.Element:
+    """Given a table containing at most one page's worth of entries, creates a page of labels.
+    If there are less entries than a full page, returns a partial page."""
+    sheet = self._create_sheet()
 
     (margin_x, margin_y) = self.sheet.get_margins(self.size)
     for row_num, row in enumerate(table):
-      sheet_num = row_num % self.sheet.labels_per_sheet()
-      if sheet_num == 0:
-        sheets.append(self.create_sheet())
+      if row_num >= self.sheet.labels_per_sheet():
+        raise BadTemplateException(f'table contains more entries than {self.sheet.labels_per_sheet()} per page')
 
-      count_x = sheet_num % self.sheet.count[0]
-      count_y = sheet_num // self.sheet.count[0]
+      count_x = row_num % self.sheet.count[0]
+      count_y = row_num // self.sheet.count[0]
       offset_x = margin_x + (self.size[0] + self.sheet.space[0]) * count_x
       offset_y = margin_y + (self.size[1] + self.sheet.space[1]) * count_y
 
       instance = self.apply_instance(row, table, row_num)
       instance.attrib['transform'] = f'translate({offset_x.to_px()}, {offset_y.to_px()})'
-      sheets[-1].append(instance)
+      sheet.append(instance)
 
-    return sheets
+    return sheet

--- a/labelcore/SvgTemplate.py
+++ b/labelcore/SvgTemplate.py
@@ -86,6 +86,9 @@ class SvgTemplate:
         self.template_elts.append(deepcopy(child))
         self.skeleton.remove(child)
 
+  def get_sheet_count(self) -> Tuple[int, int]:
+    return self.sheet.count
+
   def _create_instance(self) -> ET.Element:
     """Creates the top-level SVG object for a single label."""
     return deepcopy(self.skeleton)

--- a/labelcore/SvgTemplate.py
+++ b/labelcore/SvgTemplate.py
@@ -1,12 +1,12 @@
-import xml.etree.ElementTree as ET
-from typing import Any, Dict, Callable, Optional, cast, List, Tuple, OrderedDict
-from copy import deepcopy, copy
-
 import os.path
+import xml.etree.ElementTree as ET
+from copy import deepcopy, copy
+from typing import Any, Dict, Callable, cast, List, Tuple
+
 from labelfrontend import LabelSheet
 from labelfrontend.units import LengthDimension
-from .common import BadTemplateException, SVG_NAMESPACE, NAMESPACES, SVG_GRAPHICS_TAGS
 from .GroupReplacer import GroupReplacer
+from .common import BadTemplateException, SVG_NAMESPACE, NAMESPACES, SVG_GRAPHICS_TAGS
 
 
 def get_text_of(elt: ET.Element) -> str:

--- a/labelcore/__init__.py
+++ b/labelcore/__init__.py
@@ -1,5 +1,6 @@
 # Core classes, not intended to be user-facing
 from .SvgTemplate import SvgTemplate
+from .InkscapeSubprocess import InkscapeSubprocess
 
 from .common import SVG_NAMESPACE, NAMESPACES, BadTemplateException
 from .GroupReplacer import GroupReplacer, RectGroupReplacer

--- a/labelfrontend/Code128.py
+++ b/labelfrontend/Code128.py
@@ -1,5 +1,7 @@
 from typing import List, cast
 import xml.etree.ElementTree as ET
+
+from labelcore import SvgTemplate
 from .external.Code128 import code128_widths
 
 from labelcore.GroupReplacer import RectGroupReplacer
@@ -24,7 +26,7 @@ class Code128(RectGroupReplacer):
     self.quiet = quiet
     self.fill = fill
 
-  def process_rect(self, rect: ET.Element) -> List[ET.Element]:
+  def process_rect(self, context: SvgTemplate, rect: ET.Element) -> List[ET.Element]:
     x = LengthDimension.from_str(rect.attrib['x'])
     width = LengthDimension.from_str(rect.attrib['width'])
 

--- a/labelfrontend/Svg.py
+++ b/labelfrontend/Svg.py
@@ -1,7 +1,9 @@
 from enum import Enum
 from typing import List
 import xml.etree.ElementTree as ET
+import os.path
 
+from labelcore import SvgTemplate
 from labelcore.GroupReplacer import RectGroupReplacer
 from labelcore.common import SVG_NAMESPACE
 from .units import LengthDimension
@@ -25,8 +27,8 @@ class Svg(RectGroupReplacer):
     self.filename = filename
     self.scaling = scaling
 
-  def process_rect(self, rect: ET.Element) -> List[ET.Element]:
-    svg = ET.parse(self.filename).getroot()
+  def process_rect(self, context: SvgTemplate, rect: ET.Element) -> List[ET.Element]:
+    svg = ET.parse(os.path.join(os.path.dirname(context.file_abspath), self.filename)).getroot()
     assert svg.tag == f"{SVG_NAMESPACE}svg", f"loaded file {self.filename} root tag is not svg, got {svg.tag}"
     assert 'width' in svg.attrib and 'height' in svg.attrib, f"loaded svg {self.filename} missing width or height"
 

--- a/labelprinter.py
+++ b/labelprinter.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
   # TODO: support user-defineable generated filename
   args = parser.parse_args()
 
-  template = SvgTemplate(ET.parse(args.template))
+  template = SvgTemplate(args.template)
 
 
   def canonicalize_row_dict(row_dict: Dict[str, str]) -> Tuple[Tuple[str, str], ...]:
@@ -66,7 +66,7 @@ if __name__ == '__main__':
         if row_set not in last_seen_set and last_mod_time is not None:
           print(f"Printing: {row_dict}")
 
-          label = template.create_single()
+          label = template._create_instance()
           instance = template.apply_instance(row_dict, all_row_dicts, row_index)
           label.append(instance)
           root = ET.ElementTree(label)

--- a/labelprinter.py
+++ b/labelprinter.py
@@ -8,7 +8,7 @@ from typing import Dict, Tuple
 import win32api  # type:ignore
 import win32print  # type:ignore
 
-from labelcore import SvgTemplate
+from labelcore import SvgTemplate, InkscapeSubprocess
 
 import subprocess
 
@@ -32,12 +32,7 @@ if __name__ == '__main__':
     # Discard empty cells - to not print everything is a new row is added
     return tuple(sorted([(k, v) for (k, v) in row_dict.items() if v]))
 
-  # We use Inkscape instead of ReportLab / svglib because svglib doesn't seem to render
-  # some features correctly, like flowRegion.
-  # Inkscape in shell mode is also pretty responsive.
-
-  # We don't wait for Inkscape to start here, instead the command will be batched for when it is ready.
-  p = subprocess.Popen("inkscape --shell", stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+  inkscape = InkscapeSubprocess()
 
   last_mod_time = None  # None means initial read, and to not print anythign
   last_seen_set = set()
@@ -74,8 +69,7 @@ if __name__ == '__main__':
 
           if os.path.exists('temp.pdf'):
             os.remove('temp.pdf')
-          p.stdin.write(b'file-open:temp.svg;export-filename:temp.pdf;export-do;\r\n')
-          p.stdin.flush()
+          inkscape.convert('temp.svg', 'temp.pdf')
           while not os.path.exists('temp.pdf'):  # wait for file creation
             time.sleep(0.25)
 

--- a/pysvglabel.py
+++ b/pysvglabel.py
@@ -1,9 +1,7 @@
 import argparse
 import csv
-import xml.etree.ElementTree as ET
 
 from labelcore import SvgTemplate
-
 
 if __name__ == '__main__':
   parser = argparse.ArgumentParser(description='Create label sheets from SVG templates.')

--- a/pysvglabel.py
+++ b/pysvglabel.py
@@ -12,10 +12,14 @@ if __name__ == '__main__':
   parser.add_argument('csv', type=str,
                       help='Input CSV data file.')
   parser.add_argument('output', type=str,
-                      help="Filename to write outputs to. Must end in .svg."
-                           + " If multiple sheets are needed, appends a prefix to the second one, starting with _2."
-                           + " (future versions may auto-detect output format by the extension)")
+                      help="Filename to write outputs to. Can have .svg or .pdf extensions."
+                           + " If multiple sheets are needed, appends a prefix to the second one, starting with _2.")
+  parser.add_argument('--print', type=str,
+                      help="Optional printer name, to send output files to a printer as they are generated."
+                           + " The output must be a PDF.")
   args = parser.parse_args()
 
   reader = csv.DictReader(args.csv)
-  template = SvgTemplate(ET.parse(args.template))
+  template = SvgTemplate(args.template)
+
+

--- a/pysvglabel.py
+++ b/pysvglabel.py
@@ -1,21 +1,10 @@
 import argparse
 import csv
-import subprocess
 import xml.etree.ElementTree as ET
 import os.path
 from typing import Optional
 
-from labelcore import SvgTemplate
-
-
-class InkscapeSubprocess:
-  def __init__(self) -> None:
-    self.process = subprocess.Popen("inkscape --shell", stdin=subprocess.PIPE, stdout=subprocess.PIPE)
-
-  def convert(self, filename_in: str, filename_out: str) -> None:
-    assert self.process.stdin
-    self.process.stdin.write(str.encode(f'file-open:{filename_in};export-filename:{filename_out};export-do;\r\n'))
-    self.process.stdin.flush()
+from labelcore import SvgTemplate, InkscapeSubprocess
 
 
 if __name__ == '__main__':
@@ -67,7 +56,7 @@ if __name__ == '__main__':
       root.write(file)
       outfiles.append(filename + '.svg')
 
-    if inkscape is not None:
+    if inkscape:
       inkscape.convert(filename + '.svg', filename + '.pdf')
       outfiles.append(filename + '.pdf')
 
@@ -77,4 +66,5 @@ if __name__ == '__main__':
       win32api.ShellExecute(0, "print", filename + '.pdf', f'/d:"{args.print}"', ".", 0)
       print(f'Print to {args.print}')
 
-  # TODO optional printing
+  if inkscape:
+    inkscape.close()

--- a/tests/LabelTestCase.py
+++ b/tests/LabelTestCase.py
@@ -1,12 +1,16 @@
 import unittest
 
 import xml.etree.ElementTree as ET
-from typing import List
+import os.path
+import inspect
 
 
 class LabelTestCase(unittest.TestCase):
-  def write_labels(self, sheets: List[ET.Element]) -> None:
-    for i, sheet in enumerate(sheets):
-      with open(f'out/{self.__class__.__name__}_{self._testMethodName}_{i}.svg', 'wb') as file:
-        root = ET.ElementTree(sheet)
-        root.write(file)
+  def get_base_dir(self) -> str:
+    return os.path.dirname(inspect.getfile(self.__class__))
+
+  def write_label(self, sheet: ET.Element) -> None:
+    with open(os.path.join(self.get_base_dir(), 'out', f'{self.__class__.__name__}_{self._testMethodName}.svg'),
+              'wb') as file:
+      root = ET.ElementTree(sheet)
+      root.write(file)

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -1,23 +1,23 @@
 import csv
 
+import os.path
 import xml.etree.ElementTree as ET
 from labelcore import SvgTemplate, NAMESPACES
 from labelcore.SvgTemplate import get_text_of
-from LabelTestCase import LabelTestCase
+from .LabelTestCase import LabelTestCase
 
 
 class SimpleLabelTestCase(LabelTestCase):
   def test_simple(self) -> None:
-    with open('test_simple.csv', newline='') as csvfile:
+    with open(os.path.join(self.get_base_dir(), 'test_simple.csv'), newline='') as csvfile:
       reader = csv.DictReader(csvfile)
       table = [row for row in reader]
-    template = SvgTemplate(ET.parse("simple_1.75x0.5.svg"))
+    template = SvgTemplate(os.path.join(self.get_base_dir(), "simple_1.75x0.5.svg"))
 
-    sheets = template.apply_table(table)
-    self.write_labels(sheets)
+    sheet = template.apply_page(table)
+    self.write_label(sheet)
 
-    self.assertEqual(len(sheets), 1)
-    groups = sheets[0].findall('svg:g', NAMESPACES)
+    groups = sheet.findall('svg:g', NAMESPACES)
     self.assertEqual(len(groups), 5)
 
     # TODO text_of should add newlines?

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -1,7 +1,6 @@
 import csv
 
 import os.path
-import xml.etree.ElementTree as ET
 from labelcore import SvgTemplate, NAMESPACES
 from labelcore.SvgTemplate import get_text_of
 from .LabelTestCase import LabelTestCase

--- a/tests/test_subsvg.py
+++ b/tests/test_subsvg.py
@@ -1,7 +1,6 @@
 import csv
 
 import os.path
-import xml.etree.ElementTree as ET
 from labelcore import SvgTemplate, NAMESPACES
 from .LabelTestCase import LabelTestCase
 

--- a/tests/test_subsvg.py
+++ b/tests/test_subsvg.py
@@ -1,21 +1,20 @@
 import csv
 
+import os.path
 import xml.etree.ElementTree as ET
 from labelcore import SvgTemplate, NAMESPACES
-from labelcore.SvgTemplate import get_text_of
-from LabelTestCase import LabelTestCase
+from .LabelTestCase import LabelTestCase
 
 
 class SubSvgTestCase(LabelTestCase):
-  def test_simple(self) -> None:
-    with open('test_subsvg.csv', newline='') as csvfile:
+  def test_subsvg(self) -> None:
+    with open(os.path.join(self.get_base_dir(), 'test_subsvg.csv'), newline='') as csvfile:
       reader = csv.DictReader(csvfile)
       table = [row for row in reader]
-    template = SvgTemplate(ET.parse("test_subsvg.svg"))
+    template = SvgTemplate(os.path.join(self.get_base_dir(), "test_subsvg.svg"))
 
-    sheets = template.apply_table(table)
-    self.write_labels(sheets)
+    sheet = template.apply_page(table)
+    self.write_label(sheet)
 
-    self.assertEqual(len(sheets), 1)
-    groups = sheets[0].findall('svg:g', NAMESPACES)
+    groups = sheet.findall('svg:g', NAMESPACES)
     self.assertEqual(len(groups), 5)


### PR DESCRIPTION
Implement the top-level label sheet generator script.

- Refactor template to have single-page interface
- Use absolute paths in tests
- Add context to GroupReplacer
- Use template-relative paths internally in GroupReplacer
- Split Inkscape subprocess into its own class