### PR TITLE
Inkscape multipage support

### DIFF
--- a/labelcore/SvgTemplate.py
+++ b/labelcore/SvgTemplate.py
@@ -203,7 +203,7 @@ class SvgTemplate:
   def apply_page(self, table: List[Dict[str, str]]) -> ET.Element:
     """Given a table containing at most one page's worth of entries, creates a page of labels.
     If there are less entries than a full page, returns a partial page."""
-    sheet = self.create_sheet()
+    new_root = ET.Element(f'{SVG_NAMESPACE}g')
 
     (margin_x, margin_y) = self.sheet.get_margins(self.size)
     (viewbox_scale_x, viewbox_scale_y) = self._viewbox_scale()
@@ -224,9 +224,9 @@ class SvgTemplate:
       instance.attrib['transform'] = \
         f'translate({offset_x.to_px() * viewbox_scale_x}, {offset_y.to_px() * viewbox_scale_y})'
 
-      sheet.append(instance)
+      new_root.append(instance)
 
-    return sheet
+    return new_root
 
   def run_end(self) -> None:
     """Call this to run the end block of the template."""

--- a/labelcore/SvgTemplate.py
+++ b/labelcore/SvgTemplate.py
@@ -175,7 +175,6 @@ class SvgTemplate:
       text_child_elts = filter_text_elts(list(elt))
       command_child_elts = [text_child_elt for text_child_elt in text_child_elts
                             if get_text_of(text_child_elt).startswith('🐍')]
-
       if len(command_child_elts) == 1:
         command_elt = command_child_elts[0]
         code = get_text_of(command_elt).strip('🐍')
@@ -190,9 +189,10 @@ class SvgTemplate:
         elt.extend(new_elts)
       elif len(command_child_elts) > 1:
         raise BadTemplateException('cannot have multiple 🐍 textboxes in the same group')
-      else:
-        for child in text_child_elts:
-          process_text(child)
+
+      text_child_elts = filter_text_elts(list(elt))  # make sure to process text on the output of command blocks too
+      for child in text_child_elts:
+        process_text(child)
 
     for elt in self.template_elts:
       new_elt = deepcopy(elt)

--- a/labelcore/SvgTemplate.py
+++ b/labelcore/SvgTemplate.py
@@ -209,7 +209,7 @@ class SvgTemplate:
         assert len(viewbox_split) == 4, f"viewBox must have 4 components, got {self.skeleton.attrib['viewBox']}"
         width = LengthDimension.from_str(self.skeleton.attrib['width'])
         height = LengthDimension.from_str(self.skeleton.attrib['height'])
-        assert viewbox_split[0] == '0' and viewbox_split[1] == '0', "TODO support non-zeo viewBox origin"
+        assert viewbox_split[0] == '0' and viewbox_split[1] == '0', "TODO support non-zero viewBox origin"
         scale_factor_x = (width / float(viewbox_split[2])).to_px()
         scale_factor_y = (height / float(viewbox_split[3])).to_px()
         instance.attrib['transform'] = instance.attrib['transform'] + f' scale({scale_factor_x} {scale_factor_y})'

--- a/labelprinter.py
+++ b/labelprinter.py
@@ -34,7 +34,7 @@ if __name__ == '__main__':
 
   inkscape = InkscapeSubprocess()
 
-  last_mod_time = None  # None means initial read, and to not print anythign
+  last_mod_time = None  # None means initial read, and to not print anything
   last_seen_set = set()
   while True:
     if not os.path.isfile(args.csv):

--- a/pysvglabel.py
+++ b/pysvglabel.py
@@ -52,7 +52,7 @@ if __name__ == '__main__':
       inkscape.convert(filename + '.svg', filename + '.pdf')
       outfiles.append(filename + '.pdf')
 
-    print(f'Wrote page {page_num + 1}/{len(page_tables)}: {", ".join(outfiles)}')
+    print(f'Wrote {", ".join(outfiles)}')
 
     if args.print:
       win32api.ShellExecute(0, "print", filename + '.pdf', f'/d:"{args.print}"', ".", 0)
@@ -83,10 +83,18 @@ if __name__ == '__main__':
         filename = output_name + f'_{page_num + 1}'
       write_file(filename, sheet)
     else:
+      assert 'transform' not in page.attrib
+      page.attrib['transform'] = f'translate({page_num * template.sheet.page[0].to_px() * viewbox_scale_x}, 0)'
       multipage.append(page)
+
       namedview_page = ET.Element('{http://www.inkscape.org/namespaces/inkscape}page')
-      
+      namedview_page.attrib['x'] = str(page_num * template.sheet.page[0].to_px() * viewbox_scale_x)
+      namedview_page.attrib['y'] = '0'
+      namedview_page.attrib['width'] = str(template.sheet.page[0].to_px() * viewbox_scale_x)
+      namedview_page.attrib['height'] = str(template.sheet.page[1].to_px() * viewbox_scale_y)
       namedview.append(namedview_page)
+
+      print(f'Generate page {page_num}')
 
   if args.inkscape_multipage:
     write_file(output_name, multipage)

--- a/pysvglabel.py
+++ b/pysvglabel.py
@@ -43,7 +43,8 @@ if __name__ == '__main__':
   page_tables = [table[start: start + template_page_count]
                  for start in range(0, len(table), template_page_count)]
   for (page_num, page_table) in enumerate(page_tables):
-    page = template.apply_page(page_table)
+    page = template.create_sheet()
+    page.append(template.apply_page(page_table))
 
     if page_num == 0:
       filename = output_name  # first page doesn't need an extension

--- a/tests/LabelTestCase.py
+++ b/tests/LabelTestCase.py
@@ -3,11 +3,19 @@ import unittest
 import xml.etree.ElementTree as ET
 import os.path
 import inspect
+from typing import Dict, List
+
+from labelcore import SvgTemplate
 
 
 class LabelTestCase(unittest.TestCase):
   def get_base_dir(self) -> str:
     return os.path.dirname(inspect.getfile(self.__class__))
+
+  def create_sheet(self, template: SvgTemplate, table: List[Dict[str, str]]) -> ET.Element:
+    sheet = template.create_sheet()
+    sheet.append(template.apply_page(table))
+    return sheet
 
   def write_label(self, sheet: ET.Element) -> None:
     with open(os.path.join(self.get_base_dir(), 'out', f'{self.__class__.__name__}_{self._testMethodName}.svg'),

--- a/tests/test_barcode.py
+++ b/tests/test_barcode.py
@@ -13,5 +13,5 @@ class BarcodeTestCase(LabelTestCase):
       table = [row for row in reader]
     template = SvgTemplate(os.path.join(self.get_base_dir(), "test_barcode.svg"))
 
-    sheet = template.apply_page(table)
+    sheet = self.create_sheet(template, table)
     self.write_label(sheet)

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -12,10 +12,10 @@ class TextColorTestCase(LabelTestCase):
       table = [row for row in reader]
     template = SvgTemplate(os.path.join(self.get_base_dir(), "test_color.svg"))
 
-    sheet = template.apply_page(table)
+    sheet = self.create_sheet(template, table)
     self.write_label(sheet)
 
-    groups = sheet.findall('svg:g', NAMESPACES)
+    groups = sheet.findall('svg:g', NAMESPACES)[0].findall('svg:g', NAMESPACES)
     self.assertEqual(len(groups), 5)
 
     # TODO text_of should add newlines?

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -13,10 +13,10 @@ class SimpleLabelTestCase(LabelTestCase):
       table = [row for row in reader]
     template = SvgTemplate(os.path.join(self.get_base_dir(), "simple_1.75x0.5.svg"))
 
-    sheet = template.apply_page(table)
+    sheet = self.create_sheet(template, table)
     self.write_label(sheet)
 
-    groups = sheet.findall('svg:g', NAMESPACES)
+    groups = sheet.findall('svg:g', NAMESPACES)[0].findall('svg:g', NAMESPACES)
     self.assertEqual(len(groups), 5)
 
     # TODO text_of should add newlines?

--- a/tests/test_subsvg.py
+++ b/tests/test_subsvg.py
@@ -12,8 +12,8 @@ class SubSvgTestCase(LabelTestCase):
       table = [row for row in reader]
     template = SvgTemplate(os.path.join(self.get_base_dir(), "test_subsvg.svg"))
 
-    sheet = template.apply_page(table)
+    sheet = self.create_sheet(template, table)
     self.write_label(sheet)
 
-    groups = sheet.findall('svg:g', NAMESPACES)
+    groups = sheet.findall('svg:g', NAMESPACES)[0].findall('svg:g', NAMESPACES)
     self.assertEqual(len(groups), 5)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -12,7 +12,7 @@ class ValidationTestCase(LabelTestCase):
       table = [row for row in reader]
     template = SvgTemplate(os.path.join(self.get_base_dir(), "test_validate.svg"))
 
-    sheet = template.apply_page(table)
+    self.create_sheet(template, table)
     template.run_end()
 
   def test_validate_fail(self) -> None:
@@ -21,6 +21,6 @@ class ValidationTestCase(LabelTestCase):
       table = [row for row in reader]
     template = SvgTemplate(os.path.join(self.get_base_dir(), "test_validate.svg"))
 
-    template.apply_page(table)
+    self.create_sheet(template, table)
     with self.assertRaises(AssertionError):
       template.run_end()


### PR DESCRIPTION
Adds the `--inkscape_multipage` flag to the main script, which instead of generating separate .svg and .pdf files for each page of labels, generates a single file using Inkscape 1.2's multipage functionality (note - not standard SVG).

Also some bugfixes and refactorings:
- Viewbox is handled at the page level, and viewbox scaling is maintained (instead of previously, where it was deleted, and instances were scaled)
- Translations for label instances are scaled by the viewbox factor
- SvgTemplate.create_sheet now a 'public API', and the caller must compose it with apply_page
- Template text application run on child elements of command blocks