### PR TITLE
Changed arguments in Popen to list for Linux compatibility

### DIFF
--- a/labelcore/InkscapeSubprocess.py
+++ b/labelcore/InkscapeSubprocess.py
@@ -10,7 +10,7 @@ class InkscapeSubprocess:
   Inkscape in shell mode is also pretty responsive.
   """
   def __init__(self) -> None:
-    self.process = subprocess.Popen("inkscape --shell", stdin=subprocess.PIPE)
+    self.process = subprocess.Popen(["inkscape", "--shell"], stdin=subprocess.PIPE)
     # don't block for Inkscape to start up, just start sending commands
 
   def convert(self, filename_in: str, filename_out: str) -> None:


### PR DESCRIPTION
I tried to run this on Linux and it seems that Popen needs to have the command and its parameters in list form so I adapted that. It should continue to run fine on Windows although I haven't tested it.

Thanks for this lovely little tool! :-)