### PR TITLE
Encapsulate chdir changes

### DIFF
--- a/labelcore/SvgTemplate.py
+++ b/labelcore/SvgTemplate.py
@@ -5,8 +5,8 @@ from typing import Any, Dict, Callable, cast, List, Tuple
 
 from .common import BadTemplateException, SVG_NAMESPACE, NAMESPACES, SVG_GRAPHICS_TAGS
 
-
 from contextlib import contextmanager
+
 
 @contextmanager
 def context_chdir(path):


### PR DESCRIPTION
Uses a context manager so chdir changes are encapsulated, otherwise this leeches into calling code especially when used as a library.

Also deletes a piece of duplicated, unused code.